### PR TITLE
Fix imports

### DIFF
--- a/armor/armor.go
+++ b/armor/armor.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // ArmorKey armors input as a public key.

--- a/crypto/decryption_core.go
+++ b/crypto/decryption_core.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	openpgp "github.com/ProtonMail/go-crypto/openpgp/v2"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 type pgpSplitReader struct {

--- a/crypto/decryption_handle.go
+++ b/crypto/decryption_handle.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // decryptionHandle collects the configuration parameters to decrypt a pgp message.

--- a/crypto/encryption_core.go
+++ b/crypto/encryption_core.go
@@ -9,7 +9,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	openpgp "github.com/ProtonMail/go-crypto/openpgp/v2"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // pgpSplitWriter type implements the PGPSplitWriter

--- a/crypto/encryption_handle.go
+++ b/crypto/encryption_handle.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	openpgp "github.com/ProtonMail/go-crypto/openpgp/v2"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // encryptionHandle collects the configuration parameters for encrypting a message.

--- a/crypto/interop_test.go
+++ b/crypto/interop_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 func TestDetachedSignaturesWithUnknownPackets(t *testing.T) {

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v3/armor"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // ---- MODELS -----

--- a/crypto/sign_handle.go
+++ b/crypto/sign_handle.go
@@ -13,7 +13,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	openpgp "github.com/ProtonMail/go-crypto/openpgp/v2"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 type signatureHandle struct {

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v3/armor"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 const signedPlainText = "Signed message\n"

--- a/crypto/verify_handle.go
+++ b/crypto/verify_handle.go
@@ -11,7 +11,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	openpgp "github.com/ProtonMail/go-crypto/openpgp/v2"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 type verifyHandle struct {

--- a/mime/mime.go
+++ b/mime/mime.go
@@ -12,7 +12,8 @@ import (
 	gomime "github.com/ProtonMail/go-mime"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 )
 
 // MIMECallbacks defines callback methods to process a MIME message.

--- a/mime/signature_collector.go
+++ b/mime/signature_collector.go
@@ -11,7 +11,8 @@ import (
 	pgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
-	"github.com/ProtonMail/gopenpgp/v3/internal"
+
+	"github.com/lovoo/gopenpgp/v3/internal"
 
 	gomime "github.com/ProtonMail/go-mime"
 )


### PR DESCRIPTION
Since we change the module's name into `module github.com/lovoo/gopenpgp/v3`, the internal package is not longer identifiable